### PR TITLE
Change settings menu item name to "Euskara"

### DIFF
--- a/src/components/displaySettings/displaySettings.template.html
+++ b/src/components/displaySettings/displaySettings.template.html
@@ -26,7 +26,7 @@
             <option value="es_DO">Español (Dominicana)</option>
             <option value="es-MX">Español (México)</option>
             <option value="et">Eesti</option>
-            <option value="eu">Basque</option>
+            <option value="eu">Euskara</option>
             <option value="fa">فارسی</option>
             <option value="fi">Suomi</option>
             <option value="fil">Filipino</option>


### PR DESCRIPTION
"Euskara" is the native way of naming Basque

**Changes**
Change settings menu item HTML name to "Euskara"

**Issues**
Fixes translation and aesthetic issues
